### PR TITLE
Fix load watcher base URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM golang:1.5-alpine
 
 ADD ./load-watcher /usr/local/bin/load-watcher
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The following metrics provider clients are currently supported:
 1) SignalFx
 2) Kubernetes Metrics Server
 
+These clients fetch CPU usage currently, support for other resources will be added later as needed.
+
 # Tutorial
 
 This tutorial will guide you to build load watcher Docker image, which can be deployed to work with Trimaran scheduler plugins.

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	baseUrl        = "/Watcher"
+	baseUrl        = "/watcher"
 	FifteenMinutes = "15m"
 	TenMinutes     = "10m"
 	FiveMinutes    = "5m"


### PR DESCRIPTION
Change Docker image to golang-alpine
Update README

Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>

Fixes https://github.com/paypal/load-watcher/issues/7