### PR TITLE
[Hotfix] Fix bug in k8s provider metric value calculation

### DIFF
--- a/pkg/metricsprovider/k8s.go
+++ b/pkg/metricsprovider/k8s.go
@@ -123,7 +123,7 @@ func (m metricsServerClient) FetchAllHostsMetrics(window *watcher.Window) (map[s
 			log.Errorf("unable to find host %v in node list", host.Name)
 			continue
 		}
-		fetchedMetric.Value = float64(host.Usage.Cpu().MilliValue()) / float64(nodeCapacityMap[host.Name])
+		fetchedMetric.Value = float64(100*host.Usage.Cpu().MilliValue()) / float64(nodeCapacityMap[host.Name])
 		metrics[host.Name] = append(metrics[host.Name], fetchedMetric)
 	}
 	return metrics, nil


### PR DESCRIPTION
As reported by @wangchen615, the value returned is [0,1] when [0,100] is expected.

Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>