### PR TITLE
resolve issue #18

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,12 +27,31 @@ func main() {
 	if err != nil {
 		log.Fatalf("unable to create client: %v", err)
 	}
+
+	// Keep the watcher server up
+	watcher := watcher.NewWatcher(client.GetFetcher())
+	watcher.StartWatching()
+
+	// Test a dummy library client
 	metrics, err := client.GetLatestWatcherMetrics()
 	if err != nil {
 		log.Errorf("unable to get watcher metrics: %v", err)
 	}
 	log.Infof("received metrics: %v", metrics)
 
-	// Keep the watcher server up
+	/*
+	// Wait for 2 seconds for watcher to get data.
+	time.Sleep(2 * time.Second)
+
+	// Test a dummy service client
+	watcherAddress := "http://localhost:2020"
+	serviceclient, err := api.NewServiceClient(watcherAddress)
+	metrics, err = serviceclient.GetLatestWatcherMetrics()
+	if err != nil {
+		log.Errorf("unable to get watcher metrics: %v", err)
+	}
+	log.Infof("received metrics: %v", metrics)
+	*/
+
 	select {}
 }

--- a/pkg/watcher/api/api.go
+++ b/pkg/watcher/api/api.go
@@ -22,4 +22,5 @@ import "github.com/paypal/load-watcher/pkg/watcher"
 type Client interface {
 	// Returns latest metrics present in load Watcher cache
 	GetLatestWatcherMetrics() (*watcher.WatcherMetrics, error)
+	GetFetcher() (watcher.MetricsProviderClient)
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -133,7 +133,7 @@ func (w *Watcher) StartWatching() {
 		log.Debugf("fetched metrics for window: %v", curWindow)
 
 		// TODO： add tags, etc.
-		watcherMetrics := metricMapToWatcherMetrics(hostMetrics, w.client.Name(), *curWindow)
+		watcherMetrics := MetricMapToWatcherMetrics(hostMetrics, w.client.Name(), *curWindow)
 		w.appendWatcherMetrics(metric, &watcherMetrics)
 	}
 
@@ -296,7 +296,7 @@ func (w *Watcher) handler(resp http.ResponseWriter, r *http.Request) {
 
 // Utility functions
 
-func metricMapToWatcherMetrics(metricMap map[string][]Metric, clientName string, window Window) WatcherMetrics {
+func MetricMapToWatcherMetrics(metricMap map[string][]Metric, clientName string, window Window) WatcherMetrics {
 	metricsMap := make(map[string]NodeMetrics)
 	for host, metricList := range metricMap {
 		nodeMetric := NodeMetrics{


### PR DESCRIPTION
This PR is to fix and close issue #18 .

The LibraryClient failed to getLatestMetrics when using it in plugins.

Make the following changes.
- Separate the watcher from the LibraryClient
- Allow the LibraryClient to fetch data only once.
- Add a dummy service client code (commented) in `main.go `.