### PR TITLE
Cherry-Pick: Populate metrics initially in cache before returning

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -140,12 +140,15 @@ func (w *Watcher) StartWatching() {
 	windowWatcher := func(duration string) {
 		for {
 			fetchOnce(duration)
-			time.Sleep(time.Minute) // This is assuming fetching of metrics won't exceed more than 1 minute. If it happens we need to throttle rate of fetches
+			// This is assuming fetching of metrics won't exceed more than 1 minute. If it happens we need to throttle rate of fetches
+			time.Sleep(time.Minute)
 		}
 	}
 
 	durations := [3]string{FifteenMinutes, TenMinutes, FiveMinutes}
 	for _, duration := range durations {
+		// Populate cache initially before returning
+		fetchOnce(duration)
 		go windowWatcher(duration)
 	}
 

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/francoispqt/gojay"
 	"github.com/stretchr/testify/assert"
@@ -125,7 +124,6 @@ func TestMain(m *testing.M) {
 	client := NewTestMetricsServerClient()
 	w = NewWatcher(client)
 	w.StartWatching()
-	time.Sleep(time.Second * 5) // buffer time fetch metrics for all windows
 
 	ret := m.Run()
 	os.Exit(ret)


### PR DESCRIPTION
Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>
(cherry picked from commit ef1b4d7efdb54e677e9e7a7b4c5af31bd51f1f53)