### PR TITLE
Add gren config

### DIFF
--- a/.grenrc
+++ b/.grenrc
@@ -1,0 +1,10 @@
+{
+    "dataSource": "milestones",
+    "groupBy": {
+        "Features:": ["enhancement", "documentation"],
+        "Bug Fixes:": ["bug"]
+    },
+    "ignoreLabels": ["help wanted", "question", "good first issue"],
+    "milestoneMatch": "{{tag_name}}",
+    "changelogFilename": "CHANGELOG.md"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## v0.1.1 (26/02/2021)
+
+#### Bug Fixes:
+
+- [**bug**] Cannot use the LibraryClient with the watcher [#18](https://github.com/paypal/load-watcher/issues/18)
+
+---
+
+## v0.1.0 (24/02/2021)
+
+#### Enhancements:
+
+- [**enhancement**] Maintaining consistent release version [#17](https://github.com/paypal/load-watcher/issues/17)
+- [**enhancement**] Move metricsprovider to internal [#15](https://github.com/paypal/load-watcher/issues/15)
+- [**enhancement**] Need lib to run `load-watcher` client [#12](https://github.com/paypal/load-watcher/issues/12)
+- [**enhancement**] Prometheus Client is Missing [#10](https://github.com/paypal/load-watcher/issues/10)
+- [**documentation**][**enhancement**] Dockerfile and k8s deployment tutorial are needed [#5](https://github.com/paypal/load-watcher/issues/5)
+
+#### Bug Fixes:
+
+- [**bug**] Is there some errors? [#7](https://github.com/paypal/load-watcher/issues/7)


### PR DESCRIPTION
Add changelog generated with gren

[gren](https://github.com/github-tools/github-release-notes) is a release/changelog manager for GitHub repos.

Fixes https://github.com/paypal/load-watcher/issues/36

Signed-off-by: Abdul Qadeer <aqadeer@paypal.com>