### PR TITLE
Added InsecureSkipVerify option and code to support EnableOpenShiftAuth=True env configuration

### DIFF
--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	EnableOpenShiftAuth = "EnableOpenShiftAuth"
+	EnableOpenShiftAuth = "ENABLE_OPENSHIFT_AUTH"
 	DefaultPromAddress  = "http://prometheus-k8s:9090"
 	promStd             = "stddev_over_time"
 	promAvg             = "avg_over_time"
@@ -88,6 +88,9 @@ func NewPromClient(opts watcher.MetricsProviderOpts) (watcher.MetricsProviderCli
 				kubeConfigPath = defaultKubeConfig
 			}
 			clusterConfig, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+			if err != nil {
+                return nil, fmt.Errorf("failed to get kubernetes config: %v", err)
+            }
 		}
 
 		// Create the client for kubernetes
@@ -182,7 +185,7 @@ func (s promClient) FetchHostMetrics(host string, window *watcher.Window) ([]wat
 	return metricList, anyerr
 }
 
-// FetchAllHostsMetrics Fetch all host metrics with different operators (avg_over_time, stddev_over_time) and diffrent resource types (CPU, Memory)
+// FetchAllHostsMetrics Fetch all host metrics with different operators (avg_over_time, stddev_over_time) and different resource types (CPU, Memory)
 func (s promClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]watcher.Metric, error) {
 	hostMetrics := make(map[string][]watcher.Metric)
 	var anyerr error

--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -89,8 +89,8 @@ func NewPromClient(opts watcher.MetricsProviderOpts) (watcher.MetricsProviderCli
 			}
 			clusterConfig, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 			if err != nil {
-                return nil, fmt.Errorf("failed to get kubernetes config: %v", err)
-            }
+				return nil, fmt.Errorf("failed to get kubernetes config: %v", err)
+			}
 		}
 
 		// Create the client for kubernetes

--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	EnableOpenShiftAuth = "EnableOpenShiftAuth"
 	DefaultPromAddress = "http://prometheus-k8s:9090"
 	promStd            = "stddev_over_time"
 	promAvg            = "avg_over_time"
@@ -74,7 +75,10 @@ func NewPromClient(opts watcher.MetricsProviderOpts) (watcher.MetricsProviderCli
 
 	// Ignore TLS verify errors if InsecureSkipVerify is set
 	roundTripper := api.DefaultRoundTripper
-	if opts.EnableOpenShiftAuth{
+
+	// Check if EnableOpenShiftAuth is set.
+	_, enableOpenShiftAuth := os.LookupEnv(EnableOpenShiftAuth)
+	if enableOpenShiftAuth{
 		// Create the config for kubernetes client
 		config, err := rest.InClusterConfig()
 		if err != nil {

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -26,6 +26,7 @@ const (
 	MetricsProviderNameKey    = "METRICS_PROVIDER_NAME"
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
+	SkipInsecureVerify	= "SkipInsecureVerify"
 )
 
 var (
@@ -40,6 +41,7 @@ func init() {
 	}
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
+	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(SkipInsecureVerify)
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher
@@ -60,4 +62,5 @@ type MetricsProviderOpts struct {
 	Name      string
 	Address   string
 	AuthToken string
+	InsecureSkipVerify	bool
 }

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -26,7 +26,7 @@ const (
 	MetricsProviderNameKey    = "METRICS_PROVIDER_NAME"
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
-	InsecureSkipVerify	= "InsecureSkipVerify"
+	InsecureSkipVerify        = "InsecureSkipVerify"
 )
 
 var (
@@ -59,8 +59,8 @@ type MetricsProviderClient interface {
 
 // Generic metrics provider options
 type MetricsProviderOpts struct {
-	Name      string
-	Address   string
-	AuthToken string
-	InsecureSkipVerify	bool
+	Name               string
+	Address            string
+	AuthToken          string
+	InsecureSkipVerify bool
 }

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -27,7 +27,6 @@ const (
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
 	InsecureSkipVerify	= "InsecureSkipVerify"
-	EnableOpenShiftAuth = "EnableOpenShiftAuth"
 )
 
 var (
@@ -43,7 +42,6 @@ func init() {
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
 	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(InsecureSkipVerify)
-	_, EnvMetricProviderOpts.EnableOpenShiftAuth = os.LookupEnv(EnableOpenShiftAuth)
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher
@@ -65,5 +63,4 @@ type MetricsProviderOpts struct {
 	Address   string
 	AuthToken string
 	InsecureSkipVerify	bool
-	EnableOpenShiftAuth	bool
 }

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -27,6 +27,7 @@ const (
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
 	InsecureSkipVerify	= "InsecureSkipVerify"
+	EnableOpenShiftAuth = "EnableOpenShiftAuth"
 )
 
 var (
@@ -42,6 +43,7 @@ func init() {
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
 	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(InsecureSkipVerify)
+	_, EnvMetricProviderOpts.EnableOpenShiftAuth = os.LookupEnv(EnableOpenShiftAuth)
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher
@@ -63,4 +65,5 @@ type MetricsProviderOpts struct {
 	Address   string
 	AuthToken string
 	InsecureSkipVerify	bool
+	EnableOpenShiftAuth	bool
 }

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -44,7 +44,7 @@ func init() {
 	}
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
-	insecureVerify, ok := os.LookupEnv(InsecureSkipVerify)
+	insecureVerify, _ := os.LookupEnv(InsecureSkipVerify)
 	if strings.ToLower(insecureVerify) == "true" {
         EnvMetricProviderOpts.InsecureSkipVerify = true
     } else {

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package watcher
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 const (
 	K8sClientName      = "KubernetesMetricsServer"
@@ -26,7 +29,7 @@ const (
 	MetricsProviderNameKey    = "METRICS_PROVIDER_NAME"
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
-	InsecureSkipVerify        = "InsecureSkipVerify"
+	InsecureSkipVerify        = "INSECURE_SKIP_VERIFY"
 )
 
 var (
@@ -41,7 +44,12 @@ func init() {
 	}
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
-	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(InsecureSkipVerify)
+	insecureVerify, ok := os.LookupEnv(InsecureSkipVerify)
+	if strings.ToLower(insecureVerify) == "true" {
+        EnvMetricProviderOpts.InsecureSkipVerify = true
+    } else {
+        EnvMetricProviderOpts.InsecureSkipVerify = false
+    }
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -46,10 +46,10 @@ func init() {
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
 	insecureVerify, _ := os.LookupEnv(InsecureSkipVerify)
 	if strings.ToLower(insecureVerify) == "true" {
-        EnvMetricProviderOpts.InsecureSkipVerify = true
-    } else {
-        EnvMetricProviderOpts.InsecureSkipVerify = false
-    }
+		EnvMetricProviderOpts.InsecureSkipVerify = true
+	} else {
+		EnvMetricProviderOpts.InsecureSkipVerify = false
+	}
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher

--- a/pkg/watcher/metricsprovider.go
+++ b/pkg/watcher/metricsprovider.go
@@ -26,7 +26,7 @@ const (
 	MetricsProviderNameKey    = "METRICS_PROVIDER_NAME"
 	MetricsProviderAddressKey = "METRICS_PROVIDER_ADDRESS"
 	MetricsProviderTokenKey   = "METRICS_PROVIDER_TOKEN"
-	SkipInsecureVerify	= "SkipInsecureVerify"
+	InsecureSkipVerify	= "InsecureSkipVerify"
 )
 
 var (
@@ -41,7 +41,7 @@ func init() {
 	}
 	EnvMetricProviderOpts.Address, ok = os.LookupEnv(MetricsProviderAddressKey)
 	EnvMetricProviderOpts.AuthToken, ok = os.LookupEnv(MetricsProviderTokenKey)
-	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(SkipInsecureVerify)
+	_, EnvMetricProviderOpts.InsecureSkipVerify = os.LookupEnv(InsecureSkipVerify)
 }
 
 // Interface to be implemented by any metrics provider client to interact with Watcher

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -100,7 +100,7 @@ type NodeMetrics struct {
 	Metadata Metadata `json:"metadata,omitempty"`
 }
 
-// Returns a new initialised Watcher
+// NewWatcher Returns a new initialised Watcher
 func NewWatcher(client MetricsProviderClient) *Watcher {
 	sizePerWindow := 5
 	return &Watcher{
@@ -114,7 +114,7 @@ func NewWatcher(client MetricsProviderClient) *Watcher {
 	}
 }
 
-// This function needs to be called to begin actual watching
+// StartWatching This function needs to be called to begin actual watching
 func (w *Watcher) StartWatching() {
 	w.mutex.RLock()
 	if w.isStarted {
@@ -181,13 +181,13 @@ func (w *Watcher) StartWatching() {
 	log.Info("Started watching metrics")
 }
 
-// StartWatching() should be called before calling this.
-// It starts from 15 minute window, and falls back to 10 min, 5 min windows subsequently if metrics are not present
+// GetLatestWatcherMetrics It starts from 15 minute window, and falls back to 10 min, 5 min windows subsequently
+// if metrics are not present. StartWatching() should be called before calling this.
 func (w *Watcher) GetLatestWatcherMetrics(duration string) (*WatcherMetrics, error) {
 	w.mutex.RLock()
 	defer w.mutex.RUnlock()
 	if !w.isStarted {
-		return nil, errors.New("need to call StartWatching() first!")
+		return nil, errors.New("need to call StartWatching() first")
 	}
 
 	switch {


### PR DESCRIPTION
This commit will introduce `InsecureSkipVerify` option for MetricProvider, so developers can choose to skip the verification of HTTPs requests by adding `InsecureSkipVerify: True`  for Prometheus queries. This is particular useful for clusters running on GCP and AWS as they by default do not allow HTTPs access with tokens.

We also add support to enable OpenShift Authentications for OpenShift clusters via allowing developers to configure environment variable `EnableOpenShiftAuth=True`.

This will resolve and close issue #48 