### PR TITLE
Support of Bandwidth and Storage metrics

### DIFF
--- a/pkg/watcher/internal/metricsprovider/signalfx.go
+++ b/pkg/watcher/internal/metricsprovider/signalfx.go
@@ -65,7 +65,7 @@ func NewSignalFxClient(opts watcher.MetricsProviderOpts) (watcher.MetricsProvide
 		return nil, fmt.Errorf("metric provider name should be %v, found %v", watcher.SignalFxClientName, opts.Name)
 	}
 	tlsConfig := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // TODO(aqadeer): Figure out a secure way to let users add SSL certs
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify}, // TODO(aqadeer): Figure out a secure way to let users add SSL certs
 	}
 	hostNameSuffix, _ := os.LookupEnv(signalFxHostNameSuffixKey)
 	clusterName, _ := os.LookupEnv(signalFxClusterName)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -43,6 +43,8 @@ const (
 	FiveMinutes     = "5m"
 	CPU             = "CPU"
 	Memory          = "Memory"
+	Bandwidth       = "Bandwidth"
+	Storage         = "Storage"
 	Average         = "AVG"
 	Std             = "STD"
 	Latest          = "Latest"


### PR DESCRIPTION
#### What type of PR is this?

Addition of bandwidth and storage metrics in load-watcher.

#### Related issue

#58

#### Summary

Additional metrics:

```
promTransBandMetric     = "instance:node_network_transmit_bytes:rate:sum"
promTransBandDropMetric = "instance:node_network_transmit_drop_excluding_lo:rate5m"
promRecBandMetric       = "instance:node_network_receive_bytes:rate:sum"
promRecBandDropMetric   = "instance:node_network_receive_drop_excluding_lo:rate5m"
promDiskIOMetric        = "instance_device:node_disk_io_time_seconds:rate5m"
```



