### PR TITLE
allow users to change the filter keys in signalfx

### DIFF
--- a/pkg/watcher/internal/metricsprovider/k8s.go
+++ b/pkg/watcher/internal/metricsprovider/k8s.go
@@ -75,16 +75,16 @@ func NewMetricsServerClient() (watcher.MetricsProviderClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return metricsServerClient{
+	return &metricsServerClient{
 		metricsClientSet: metricsClientSet,
 		coreClientSet:    clientSet}, nil
 }
 
-func (m metricsServerClient) Name() string {
+func (m *metricsServerClient) Name() string {
 	return watcher.K8sClientName
 }
 
-func (m metricsServerClient) FetchHostMetrics(host string, window *watcher.Window) ([]watcher.Metric, error) {
+func (m *metricsServerClient) FetchHostMetrics(host string, window *watcher.Window) ([]watcher.Metric, error) {
 	var metrics = []watcher.Metric{}
 
 	nodeMetrics, err := m.metricsClientSet.MetricsV1beta1().NodeMetricses().Get(context.TODO(), host, metav1.GetOptions{})
@@ -112,7 +112,7 @@ func (m metricsServerClient) FetchHostMetrics(host string, window *watcher.Windo
 	return metrics, nil
 }
 
-func (m metricsServerClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]watcher.Metric, error) {
+func (m *metricsServerClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]watcher.Metric, error) {
 	metrics := make(map[string][]watcher.Metric)
 
 	nodeMetricsList, err := m.metricsClientSet.MetricsV1beta1().NodeMetricses().List(context.TODO(), metav1.ListOptions{})
@@ -156,7 +156,7 @@ func (m metricsServerClient) FetchAllHostsMetrics(window *watcher.Window) (map[s
 	return metrics, nil
 }
 
-func (m metricsServerClient) Health() (int, error) {
+func (m *metricsServerClient) Health() (int, error) {
 	var status int
 	m.metricsClientSet.RESTClient().Verb("HEAD").Do(context.Background()).StatusCode(&status)
 	if status != http.StatusOK {

--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -146,14 +146,14 @@ func NewPromClient(opts watcher.MetricsProviderOpts) (watcher.MetricsProviderCli
 		return nil, err
 	}
 
-	return promClient{client}, err
+	return &promClient{client}, err
 }
 
-func (s promClient) Name() string {
+func (s *promClient) Name() string {
 	return watcher.PromClientName
 }
 
-func (s promClient) FetchHostMetrics(host string, window *watcher.Window) ([]watcher.Metric, error) {
+func (s *promClient) FetchHostMetrics(host string, window *watcher.Window) ([]watcher.Metric, error) {
 	var metricList []watcher.Metric
 	var anyerr error
 
@@ -177,7 +177,7 @@ func (s promClient) FetchHostMetrics(host string, window *watcher.Window) ([]wat
 }
 
 // FetchAllHostsMetrics Fetch all host metrics with different operators (avg_over_time, stddev_over_time) and different resource types (CPU, Memory)
-func (s promClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]watcher.Metric, error) {
+func (s *promClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]watcher.Metric, error) {
 	hostMetrics := make(map[string][]watcher.Metric)
 	var anyerr error
 
@@ -203,7 +203,7 @@ func (s promClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]w
 	return hostMetrics, anyerr
 }
 
-func (s promClient) Health() (int, error) {
+func (s *promClient) Health() (int, error) {
 	req, err := http.NewRequest("HEAD", DefaultPromAddress, nil)
 	if err != nil {
 		return -1, err
@@ -218,7 +218,7 @@ func (s promClient) Health() (int, error) {
 	return 0, nil
 }
 
-func (s promClient) buildPromQuery(host string, metric string, method string, rollup string) string {
+func (s *promClient) buildPromQuery(host string, metric string, method string, rollup string) string {
 	var promQuery string
 
 	if host == allHosts {
@@ -247,7 +247,7 @@ func (s promClient) getPromResults(promQuery string) (model.Value, error) {
 	return results, nil
 }
 
-func (s promClient) promResults2MetricMap(promresults model.Value, metric string, method string, rollup string) map[string][]watcher.Metric {
+func (s *promClient) promResults2MetricMap(promresults model.Value, metric string, method string, rollup string) map[string][]watcher.Metric {
 	var metricType string
 	var operator string
 


### PR DESCRIPTION
* allow users to change filter keys (for host & cluster name) in signalfx
* use pointers instead of values for metrics clients.