### PR TITLE
Add namespace "loadwatcher" definition

### DIFF
--- a/manifests/load-watcher-deployment.yaml
+++ b/manifests/load-watcher-deployment.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loadwatcher
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
When deploy load wather service, it will automatically create namespace "loadwatcher" if it does not exist.