### PR TITLE
Add energy metrics to load-watcher

### DIFF
--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -40,20 +40,30 @@ import (
 )
 
 const (
-	EnableOpenShiftAuth     = "ENABLE_OPENSHIFT_AUTH"
-	K8sPodCAFilePath        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	DefaultPromAddress      = "http://prometheus-k8s:9090"
-	promStd                 = "stddev_over_time"
-	promAvg                 = "avg_over_time"
-	promCpuMetric           = "instance:node_cpu:ratio"
-	promMemMetric           = "instance:node_memory_utilisation:ratio"
-	promTransBandMetric     = "instance:node_network_transmit_bytes:rate:sum"
-	promTransBandDropMetric = "instance:node_network_transmit_drop_excluding_lo:rate5m"
-	promRecBandMetric       = "instance:node_network_receive_bytes:rate:sum"
-	promRecBandDropMetric   = "instance:node_network_receive_drop_excluding_lo:rate5m"
-	promDiskIOMetric        = "instance_device:node_disk_io_time_seconds:rate5m"
-	allHosts                = "all"
-	hostMetricKey           = "instance"
+	EnableOpenShiftAuth          = "ENABLE_OPENSHIFT_AUTH"
+	K8sPodCAFilePath             = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	DefaultPromAddress           = "http://prometheus-k8s:9090"
+	promStd                      = "stddev_over_time"
+	promAvg                      = "avg_over_time"
+	promCpuMetric                = "instance:node_cpu:ratio"
+	promMemMetric                = "instance:node_memory_utilisation:ratio"
+	promTransBandMetric          = "instance:node_network_transmit_bytes:rate:sum"
+	promTransBandDropMetric      = "instance:node_network_transmit_drop_excluding_lo:rate5m"
+	promRecBandMetric            = "instance:node_network_receive_bytes:rate:sum"
+	promRecBandDropMetric        = "instance:node_network_receive_drop_excluding_lo:rate5m"
+	promDiskIOMetric             = "instance_device:node_disk_io_time_seconds:rate5m"
+	promScaphHostPower           = "scaph_host_power_microwatts"
+	promScaphHostJoules          = "scaph_host_energy_microjoules"
+	promKeplerHostCoreJoules     = "kepler_node_core_joules_total"
+	promKeplerHostUncoreJoules   = "kepler_node_uncore_joules_total"
+	promKeplerHostDRAMJoules     = "kepler_node_dram_joules_total"
+	promKeplerHostPackageJoules  = "kepler_node_package_joules_total"
+	promKeplerHostOtherJoules    = "kepler_node_other_joules_total"
+	promKeplerHostGPUJoules      = "kepler_node_gpu_joules_total"
+	promKeplerHostPlatformJoules = "kepler_node_platform_joules_total"
+	promKeplerHostEnergyStat     = "kepler_node_energy_stat"
+	allHosts                     = "all"
+	hostMetricKey                = "instance"
 )
 
 type promClient struct {
@@ -158,7 +168,9 @@ func (s promClient) FetchHostMetrics(host string, window *watcher.Window) ([]wat
 	var anyerr error
 
 	for _, method := range []string{promAvg, promStd} {
-		for _, metric := range []string{promCpuMetric, promMemMetric, promTransBandMetric, promTransBandDropMetric, promRecBandMetric, promRecBandDropMetric, promDiskIOMetric} {
+		for _, metric := range []string{promCpuMetric, promMemMetric, promTransBandMetric, promTransBandDropMetric, promRecBandMetric, promRecBandDropMetric,
+			promDiskIOMetric, promScaphHostPower, promScaphHostJoules, promKeplerHostCoreJoules, promKeplerHostUncoreJoules, promKeplerHostDRAMJoules,
+			promKeplerHostPackageJoules, promKeplerHostOtherJoules, promKeplerHostGPUJoules, promKeplerHostPlatformJoules, promKeplerHostEnergyStat} {
 			promQuery := s.buildPromQuery(host, metric, method, window.Duration)
 			promResults, err := s.getPromResults(promQuery)
 
@@ -182,7 +194,9 @@ func (s promClient) FetchAllHostsMetrics(window *watcher.Window) (map[string][]w
 	var anyerr error
 
 	for _, method := range []string{promAvg, promStd} {
-		for _, metric := range []string{promCpuMetric, promMemMetric, promTransBandMetric, promTransBandDropMetric, promRecBandMetric, promRecBandDropMetric, promDiskIOMetric} {
+		for _, metric := range []string{promCpuMetric, promMemMetric, promTransBandMetric, promTransBandDropMetric, promRecBandMetric, promRecBandDropMetric,
+			promDiskIOMetric, promScaphHostPower, promScaphHostJoules, promKeplerHostCoreJoules, promKeplerHostUncoreJoules, promKeplerHostDRAMJoules,
+			promKeplerHostPackageJoules, promKeplerHostOtherJoules, promKeplerHostGPUJoules, promKeplerHostPlatformJoules, promKeplerHostEnergyStat} {
 			promQuery := s.buildPromQuery(allHosts, metric, method, window.Duration)
 			promResults, err := s.getPromResults(promQuery)
 
@@ -259,6 +273,26 @@ func (s promClient) promResults2MetricMap(promresults model.Value, metric string
 		metricType = watcher.Memory
 	} else if metric == promDiskIOMetric {
 		metricType = watcher.Storage
+	} else if metric == promScaphHostPower {
+		metricType = watcher.Energy
+	} else if metric == promScaphHostJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostCoreJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostUncoreJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostDRAMJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostPackageJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostOtherJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostGPUJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostPlatformJoules {
+		metricType = watcher.Energy
+	} else if metric == promKeplerHostEnergyStat {
+		metricType = watcher.Energy
 	} else {
 		metricType = watcher.Bandwidth
 	}

--- a/pkg/watcher/internal/metricsprovider/prometheus.go
+++ b/pkg/watcher/internal/metricsprovider/prometheus.go
@@ -267,34 +267,24 @@ func (s promClient) promResults2MetricMap(promresults model.Value, metric string
 
 	curMetrics := make(map[string][]watcher.Metric)
 
-	if metric == promCpuMetric {
+	switch metric {
+	case promCpuMetric: // CPU metrics
 		metricType = watcher.CPU
-	} else if metric == promMemMetric {
+	case promMemMetric: // Memory metrics
 		metricType = watcher.Memory
-	} else if metric == promDiskIOMetric {
+	case promDiskIOMetric: // Storage metrics
 		metricType = watcher.Storage
-	} else if metric == promScaphHostPower {
+	case promScaphHostPower, promScaphHostJoules, // Energy-related metrics
+		promKeplerHostCoreJoules, promKeplerHostUncoreJoules,
+		promKeplerHostDRAMJoules, promKeplerHostPackageJoules,
+		promKeplerHostOtherJoules, promKeplerHostGPUJoules,
+		promKeplerHostPlatformJoules, promKeplerHostEnergyStat:
 		metricType = watcher.Energy
-	} else if metric == promScaphHostJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostCoreJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostUncoreJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostDRAMJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostPackageJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostOtherJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostGPUJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostPlatformJoules {
-		metricType = watcher.Energy
-	} else if metric == promKeplerHostEnergyStat {
-		metricType = watcher.Energy
-	} else {
+	case promTransBandMetric, promTransBandDropMetric, // Bandwidth-related metrics
+		promRecBandMetric, promRecBandDropMetric:
 		metricType = watcher.Bandwidth
+	default:
+		metricType = watcher.Unknown
 	}
 
 	if method == promAvg {

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 /*
-	Package Watcher is responsible for watching latest metrics from metrics provider via a fetcher client.
-	It exposes an HTTP REST endpoint to get these metrics, in addition to application API via clients
-	This also uses a fast json parser
+Package Watcher is responsible for watching latest metrics from metrics provider via a fetcher client.
+It exposes an HTTP REST endpoint to get these metrics, in addition to application API via clients
+This also uses a fast json parser
 */
 package watcher
 
@@ -45,6 +45,7 @@ const (
 	Memory          = "Memory"
 	Bandwidth       = "Bandwidth"
 	Storage         = "Storage"
+	Energy          = "Energy"
 	Average         = "AVG"
 	Std             = "STD"
 	Latest          = "Latest"

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -46,6 +46,7 @@ const (
 	Bandwidth       = "Bandwidth"
 	Storage         = "Storage"
 	Energy          = "Energy"
+	Unknown         = "Unknown"
 	Average         = "AVG"
 	Std             = "STD"
 	Latest          = "Latest"


### PR DESCRIPTION
**What type of PR is this?**

Addition of energy metrics in load-watcher.

**Related issue**

https://github.com/paypal/load-watcher/issues/72

**Summary**

Additional metrics:

```
promScaphHostPower           = "scaph_host_power_microwatts"
promScaphHostJoules          = "scaph_host_energy_microjoules"
promKeplerHostCoreJoules     = "kepler_node_core_joules_total"
promKeplerHostUncoreJoules   = "kepler_node_uncore_joules_total"
promKeplerHostDRAMJoules     = "kepler_node_dram_joules_total"
promKeplerHostPackageJoules  = "kepler_node_package_joules_total"
promKeplerHostOtherJoules    = "kepler_node_other_joules_total"
promKeplerHostGPUJoules      = "kepler_node_gpu_joules_total"
promKeplerHostPlatformJoules = "kepler_node_platform_joules_total"
promKeplerHostEnergyStat     = "kepler_node_energy_stat"
```